### PR TITLE
fixed values copy

### DIFF
--- a/lib/properties.py
+++ b/lib/properties.py
@@ -141,7 +141,7 @@ def gen_properties_to_test(properties, ranged_properties):
             if key in to_yield:
                 to_yield[key].update(values.copy())
             else:
-                to_yield[key] = values.copy()
+                to_yield[key] = copy.copy(values)
         yield to_yield
 
 


### PR DESCRIPTION
Hey man, i was checking this out and the python script didnt run with values.copy(), saw you imported the copy library so i did a shallow copy instead. you can check it out if it helps, I was running python 3.7.5.